### PR TITLE
Allow running ts directly via node.js and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,20 @@ Behold my latest inator! The `linkinator` provides an API and CLI for crawling w
 
 ## Installation
 
+Install and run npm packages:
+
 ```sh
 npm install @avenga/linkinator
+npm start -- https://example.com
 ```
 
-Not into the whole node.js or npm thing?  You can also download a standalone binary that bundles node, linkinator, and anything else you need.  See [releases](https://github.com/avenga/linkinator/releases).
+You can also use the package directly with npx:
+
+```sh
+npx @avenga/linkinator https://example.com
+```
+
+You can also download the source code here: [releases](https://github.com/avenga/linkinator/releases).
 
 ## Command Usage
 
@@ -115,49 +124,49 @@ $ linkinator LOCATIONS [ --arguments ]
 You can run a shallow scan of a website for busted links:
 
 ```sh
-npx linkinator https://jbeckwith.com
+npx @avenga/linkinator https://example.com
 ```
 
 That was fun.  What about local files?  The linkinator will stand up a static web server for yinz:
 
 ```sh
-npx linkinator ./docs
+npx @avenga/linkinator ./docs
 ```
 
 But that only gets the top level of links.  Lets go deeper and do a full recursive scan!
 
 ```sh
-npx linkinator ./docs --recurse
+npx @avenga/linkinator ./docs --recurse
 ```
 
 Aw, snap.  I didn't want that to check *those* links.  Let's skip em:
 
 ```sh
-npx linkinator ./docs --skip www.googleapis.com
+npx @avenga/linkinator ./docs --skip www.googleapis.com
 ```
 
 The `--skip` parameter will accept any regex! You can do more complex matching, or even tell it to only scan links with a given domain:
 
 ```sh
-npx linkinator http://jbeckwith.com --skip '^(?!http://jbeckwith.com)'
+npx @avenga/linkinator https://example.com --skip '^(?!https://example.com)'
 ```
 
 Maybe you're going to pipe the output to another program.  Use the `--format` option to get JSON or CSV!
 
 ```sh
-npx linkinator ./docs --format CSV
+npx @avenga/linkinator ./docs --format CSV
 ```
 
 Let's make sure the `README.md` in our repo doesn't have any busted links:
 
 ```sh
-npx linkinator ./README.md --markdown
+npx @avenga/linkinator ./README.md --markdown
 ```
 
 You know what, we better check all of the markdown files!
 
 ```sh
-npx linkinator "**/*.md" --markdown
+npx @avenga/linkinator "**/*.md" --markdown
 ```
 
 ### Configuration file
@@ -195,7 +204,7 @@ All options are optional. It should look like this:
 To load config settings outside the CWD, you can pass the `--config` flag to the `linkinator` CLI:
 
 ```sh
-npx linkinator --config /some/path/your-config.json
+npx @avenga/linkinator --config /some/path/your-config.json
 ```
 
 ## API Usage
@@ -305,7 +314,7 @@ async function complex() {
     // port: 8673,
     // recurse: true,
     // linksToSkip: [
-    //   'https://jbeckwith.com/some/link',
+    //   'https://example.com/some/link',
     //   'http://example.com'
     // ]
   });
@@ -335,7 +344,7 @@ This library supports proxies via the `HTTP_PROXY` and `HTTPS_PROXY` environment
 You may have noticed in the example, when using a glob the pattern is encapsulated in quotes:
 
 ```sh
-npx linkinator "**/*.md" --markdown
+npx @avenga/linkinator "**/*.md" --markdown
 ```
 
 Without the quotes, some shells will attempt to expand the glob paths on their own.  Various shells (bash, zsh) have different, somewhat unpredictable behaviors when left to their own devices.  Using the quotes ensures consistent, predictable behavior by letting the library expand the pattern.
@@ -345,7 +354,7 @@ Without the quotes, some shells will attempt to expand the glob paths on their o
 Oftentimes when a link fails, it's an easy to spot typo, or a clear 404.  Other times ... you may need more details on exactly what went wrong.  To see a full call stack for the HTTP request failure, use `--verbosity DEBUG`:
 
 ```sh
-npx linkinator https://jbeckwith.com --verbosity DEBUG
+npx @avenga/linkinator https://example.com --verbosity DEBUG
 ```
 
 ### Controlling Output
@@ -353,7 +362,7 @@ npx linkinator https://jbeckwith.com --verbosity DEBUG
 The `--verbosity` flag offers preset options for controlling the output, but you may want more control.  Using [`jq`](https://stedolan.github.io/jq/) and `--format JSON` - you can do just that!
 
 ```sh
-npx linkinator https://jbeckwith.com --verbosity DEBUG --format JSON | jq '.links | .[] | select(.state | contains("BROKEN"))'
+npx @avenga/linkinator https://example.com --verbosity DEBUG --format JSON | jq '.links | .[] | select(.state | contains("BROKEN"))'
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"test": "vitest",
 		"fix": "biome check --write .",
 		"lint": "biome check .",
-		"docs-test": "node build/src/cli.js ./README.md"
+		"docs-test": "node build/src/cli.js ./README.md",
+		"start": "node --experimental-transform-types src/cli.ts"
 	},
 	"dependencies": {
 		"chalk": "^5.0.0",
@@ -48,7 +49,7 @@
 		"vitest": "^3.2.4"
 	},
 	"engines": {
-		"node": ">=20",
+		"node": ">=22.7",
 		"npm": ">=9",
 		"bun": "1.2.20"
 	},

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,11 +3,11 @@
 import process from 'node:process';
 import chalk from 'chalk';
 import meow from 'meow';
-import { type Flags, getConfig } from './config.js';
-import { LinkChecker } from './index.js';
-import { Format, LogLevel, Logger } from './logger.js';
-import type { CheckOptions } from './options.js';
-import { type LinkResult, LinkState, type RetryInfo } from './types.js';
+import { type Flags, getConfig } from './config.ts';
+import { LinkChecker } from './index.ts';
+import { Format, LogLevel, Logger } from './logger.ts';
+import type { CheckOptions } from './options.ts';
+import { type LinkResult, LinkState, type RetryInfo } from './types.ts';
 
 const cli = meow(
 	`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-export { getConfig } from './config.js';
-export { check } from './utils.js';
+export { getConfig } from './config.ts';
+export { check } from './utils.ts';
 export {
 	LinkState,
-	RetryInfo,
-	FailureDetails,
-	LinkResult,
-	CrawlResult,
-} from './types.js';
-export type { CheckOptions } from './options.js';
-export { LinkChecker } from './crawler.js';
+	type RetryInfo,
+	type FailureDetails,
+	type LinkResult,
+	type CrawlResult,
+} from './types.ts';
+export type { CheckOptions } from './options.ts';
+export { LinkChecker } from './crawler.ts';

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,8 +1,8 @@
 import { Stream } from 'node:stream';
 import { WritableStream } from 'htmlparser2/WritableStream';
 import { parseSrcset } from 'srcset';
-import type { ElementMetadata } from './types.js';
-import { isCSS } from './utils.js';
+import type { ElementMetadata } from './types.ts';
+import { isCSS } from './utils.ts';
 
 type TagConfig = {
 	// Element attributes that can contain URLs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
-import { type CrawlOptions, LinkChecker } from './crawler.js';
-import type { CheckOptions, InternalCheckOptions } from './options.js';
+import { type CrawlOptions, LinkChecker } from './crawler.ts';
+import type { CheckOptions, InternalCheckOptions } from './options.ts';
 
 /**
  * Convenience method to perform a scan.

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { assert, describe, expect, it } from 'vitest';
-import { type Flags, getConfig } from '../src/config.js';
+import { type Flags, getConfig } from '../src/config.ts';
 
 describe('config', () => {
 	it('should allow passing no config', async () => {

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -8,8 +8,8 @@ import {
 	LinkState,
 	check,
 } from '../src/index.js';
-import { DEFAULT_USER_AGENT } from '../src/options.js';
-import { invertedPromise } from './utils.js';
+import { DEFAULT_USER_AGENT } from '../src/options.ts';
+import { invertedPromise } from './utils.ts';
 
 nock.disableNetConnect();
 nock.enableNetConnect('localhost');

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import { assert, afterEach, describe, it, vi } from 'vitest';
-import { LinkChecker, check } from '../src/index.js';
-import { invertedPromise } from './utils.js';
+import { LinkChecker, check } from '../src/index.ts';
+import { invertedPromise } from './utils.ts';
 
 nock.disableNetConnect();
 nock.enableNetConnect('localhost');

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { assert, afterAll, beforeAll, describe, it } from 'vitest';
-import { startWebServer } from '../src/server.js';
+import { startWebServer } from '../src/server.ts';
 
 describe('server', () => {
 	let server: Server;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,15 @@
 {
 	"compilerOptions": {
 		"strict": true,
-		"target": "ES2022",
+		"target": "esnext",
+		"module": "nodenext",
 		"declaration": true,
 		"rootDir": ".",
 		"outDir": "build",
-		"module": "Node16",
 		"moduleResolution": "Node16",
-		"allowSyntheticDefaultImports": true
+		"allowSyntheticDefaultImports": true,
+		"rewriteRelativeImportExtensions": true,
+		"verbatimModuleSyntax": true
 	},
 	"include": ["src/*.ts", "test/*.ts"]
 }


### PR DESCRIPTION
Enable directly running typescript via node.js without build/compiling.
Make typescript behave like node.js in this regard to align behaviour and errors.
Update README:

- remove references to justinbeck domain
- remove reference to binary release
- update references to npm package for npx
- update installation section