### PR TITLE
fix: update `chalk` and `strip-ansi` versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^5.0.0",
+				"chalk": "^5.6.2",
 				"escape-html": "^1.0.3",
 				"glob": "^11.0.2",
 				"htmlparser2": "^10.0.0",
@@ -33,7 +33,7 @@
 				"husky": "^9.0.11",
 				"nock": "^14.0.5",
 				"semantic-release": "^24.0.0",
-				"strip-ansi": "^7.0.1",
+				"strip-ansi": "^7.1.2",
 				"typescript": "^5.5.2",
 				"vitest": "^3.2.4"
 			},
@@ -2064,9 +2064,9 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-			"integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
 			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -8222,9 +8222,9 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"start": "node --experimental-transform-types src/cli.ts"
 	},
 	"dependencies": {
-		"chalk": "^5.0.0",
+		"chalk": "^5.6.2",
 		"escape-html": "^1.0.3",
 		"glob": "^11.0.2",
 		"htmlparser2": "^10.0.0",
@@ -45,7 +45,7 @@
 		"husky": "^9.0.11",
 		"nock": "^14.0.5",
 		"semantic-release": "^24.0.0",
-		"strip-ansi": "^7.0.1",
+		"strip-ansi": "^7.1.2",
 		"typescript": "^5.5.2",
 		"vitest": "^3.2.4"
 	},


### PR DESCRIPTION
Explicitly update `chalk` and `strip-ansi` dependencies because of versions affected with malware, more information:
https://github.com/advisories/GHSA-vfjc-p7x3-q864
https://github.com/advisories/GHSA-2v46-p5h4-248w